### PR TITLE
Fix null pointer on startup when running on Java 9

### DIFF
--- a/src/main/java/vgrazi/util/IOUtils.java
+++ b/src/main/java/vgrazi/util/IOUtils.java
@@ -10,7 +10,7 @@ public class IOUtils {
   public static String readHtmlText(String fileName) throws IOException {
     BufferedReader reader = null;
     try {
-      final InputStream stream = fileName.getClass().getResourceAsStream(fileName);
+      final InputStream stream = IOUtils.class.getResourceAsStream(fileName);
       reader = new BufferedReader(new InputStreamReader(stream));
       StringBuffer sb = new StringBuffer();
       String line;


### PR DESCRIPTION
The following error occurred when running on Java 9. 
```
Exception in thread "main" java.lang.NullPointerException
        at java.base/java.io.Reader.<init>(Unknown Source)
        at java.base/java.io.InputStreamReader.<init>(Unknown Source)
        at vgrazi.util.IOUtils.readHtmlText(IOUtils.java:14)
        at vgrazi.concurrent.samples.launcher.ConcurrentExampleLauncher.<init>(ConcurrentExampleLauncher.java:77)
        at vgrazi.concurrent.samples.launcher.ConcurrentExampleLauncher.main(ConcurrentExampleLauncher.java:70)
```
This PR will fix it