### PR TITLE
Semaphore fixes

### DIFF
--- a/src/main/java/vgrazi/util/IOUtils.java
+++ b/src/main/java/vgrazi/util/IOUtils.java
@@ -10,7 +10,7 @@ public class IOUtils {
   public static String readHtmlText(String fileName) throws IOException {
     BufferedReader reader = null;
     try {
-      final InputStream stream = fileName.getClass().getResourceAsStream(fileName);
+      final InputStream stream = IOUtils.class.getResourceAsStream(fileName);
       reader = new BufferedReader(new InputStreamReader(stream));
       StringBuffer sb = new StringBuffer();
       String line;


### PR DESCRIPTION
SemaphoreExample now correctly shows the number of available permits. 
Added the drainPermits() functionality, which allows to lower the number of maximum possible permits.